### PR TITLE
Dockerfile fixes and timing tweaks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,15 @@
-FROM node:8.2.1-wheezy
+FROM ubuntu:16.04
 
-RUN apt-get update; apt-get install -y tesseract-ocr ffmpeg imagemagick
-
+RUN apt-get update; apt-get install -y tesseract-ocr ffmpeg imagemagick curl
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
+RUN apt-get update && apt-get install nodejs
 RUN apt-get install -y python-dev python-pip; pip install livestreamer
 
 COPY . /
-
 RUN npm install
+
+ARG token
+ENV token=$token
+
+EXPOSE 3000
+CMD ["node", "app.js"]

--- a/app.js
+++ b/app.js
@@ -118,7 +118,7 @@ function getLowestStream(pool, cropsDir) {
       console.log(array);
       console.log("lowest stream: " + array[0].name);
       setCurrentStream(array[0]);
-    }, 12000);
+    }, 14000);
   });
 }
 


### PR DESCRIPTION
* The 8.1.2-wheezy nodejs docker image does not behave correctly. For
  now I've switched it to just run on ubuntu. This increases image
  build time since nodejs needs to be installed (there is no official
  nodejs ubuntu docker image that I can see).

* Dockerfile now requires a build argument, which is the twitch oauth
  token used by the app.

* Timing tweaks to ensure all streams get processed in a docker
   container.

Signed-off-by: Cullen Taylor <cullentaylor@outlook.com>