### PR TITLE
Remove integrity and crossorigin malarkey

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,10 +2,7 @@
 <html>
   <head>
     <title>PUBG Red Zone</title>
-    <script
-      src="js/jquery.js"
-      integrity="sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4="
-      crossorigin="anonymous"></script>
+    <script src="js/jquery.js"> </script>
   </head>
   <body>
     <h2>PUBG Red Zone</h2><h2 id="streamer_name">TSM_VISS</h2>


### PR DESCRIPTION
Since we're serving jquery oursleves, we don't need the integrity and
crossorigin fields.

Signed-off-by: Cullen Taylor <cullentaylor@outlook.com>